### PR TITLE
extractInferenceOutput.sh: bugfixes and LRZ-Version

### DIFF
--- a/tools/pi4u_lite/Inference/extractInferenceOutput_LRZ.sh
+++ b/tools/pi4u_lite/Inference/extractInferenceOutput_LRZ.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+module load matlab	#lad matlab module
+
 #  Helpers
 #-----------------------------------------------------
 function last_column_max_row() {
@@ -170,6 +172,7 @@ EOF
         echo ">>>   Creating the Results folders  <<<"
         echo "---------------------------------------"
 	ResultsFolder=${InputNiiPath:0:-1}_Results
+	rm -r -f ${ResultsFolder}		#old results will be removed!!
 	mkdir -p ${ResultsFolder} 
 	cp ReportFile.md ${ResultsFolder} 
 	cp MAP/MAP.nii ${ResultsFolder}
@@ -195,9 +198,11 @@ EOF
 	    sed -i 's|_std_p'"${i}"'_|'"${std[${i}]}"'|g' ReportFile.md
 	done
 
-	pandoc ReportFile.md -o ReportFile.pdf
+	#pandpandoc ReportFile.md -o ReportFile.pdf	#TODO: currecntly no easy way to get pandoc on LRZ cluster
+	echo "pandoc ReportFile.md -o ReportFile.pdf" > runLocal.sh	#create file that has to be executed on a system with pandoc
+	chmod +x runLocal.sh										#TODO: remove this workaround wehen better solution is found
 	cd ../
-	
+
 	echo " The Results are stored in:"
 	echo " ${ResultsFolder}"
 	


### PR DESCRIPTION
-  I fixed some bugs concerning the removal of already existing output files and folders.
-  Additionally, I created a _extractInferenceOutput\_**LRZ**.sh_ witch will run on the LRZ Linux cluster.
However, as the cluster has nor _pandoc_ module available yet, the generation of a results-pdf was replaced with the generation of a script that can later be executed on a machine that has _pandoc_ available to generate the _.pdf_.
This is not a nice workaround indeed, but there is unfortunately no easy way to convert a markdown to a _.pdf_ on the linux cluster at the moment.
- In general - as we do neither have root permissions nor a packet manager (afaik) on the cluster - we should think how we would like to handle the GliomaSolver suite on systems with such restrictions.
