### PR TITLE
Adapted installer for LRZ

### DIFF
--- a/INSTALL/tools/install_GliomaSolver_on_linux-64-bit.sh
+++ b/INSTALL/tools/install_GliomaSolver_on_linux-64-bit.sh
@@ -333,6 +333,8 @@ then
     if [ $LRZ != "yes" ]
     then
         echo "export LD_LIBRARY_PATH=\$LIB_BASE/gsl-install/lib/:\$LD_LIBRARY_PATH"
+    else
+        echo "export LD_LIBRARY_PATH=/lrz/sys/libraries/gsl/2.3/lib:\$LD_LIBRARY_PATH"
     fi
     echo "export PATH=\$LIB_BASE/usr/torc/bin:\$PATH"
     #cat "${SolverDir}/tools/pi4u_lite/Inference/setup_${UserName}.sh"

--- a/INSTALL/tools/install_GliomaSolver_on_linux-64-bit.sh
+++ b/INSTALL/tools/install_GliomaSolver_on_linux-64-bit.sh
@@ -15,6 +15,14 @@ select yn in "Yes" "No"; do
     esac
 done
 
+echo "Are we on the LRZ-Cluster?"
+select yn in "Yes" "No"; do
+    case $yn in
+        Yes ) LRZ="yes"; break;;         #if this variable is set to "yes" this installer will not have root privileges
+        No ) LRZ="no"; break;;
+    esac
+done
+
 
 echo "--------------------------------------"
 echo ">>> Getting prerequsites and external programms   <<<"
@@ -24,34 +32,77 @@ echo "--------------------------------------"
 
 if [ $BI = "yes" ]          # only for Bayesian Inference
 then
-    sudo apt install gcc gfortran gawk libtool texlive-full pandoc pandoc-citeproc  
-    
+
+    if [ $LRZ = "yes" ]
+    then
+
+        module purge
+        module load lrz tempdir     #obligatory
+        module load spack           #requirement for many libs
+        
+        module load intel-parallel-studio   #requires spack
+        #"intel-parallel-studio: using intel wrappers for mpicc, mpif77, etc"
+        #Intel paralell studio includes: gcc, fortran compiler, 
+
+        #gawk and libtool is allready existent at LRZ
+        module load texlive         #requires spack
+        #pandoc is not available on the LRZ (TODO: workaround)
+
+
+        #Alternativ to intel-parallel-studio:
+        #module load gcc/8           #gcc version can be changed here
+        #module load mpi.intel/2018_gcc
+        #module load caf/gfortran    #requires gcc and mpi.intel       
+
+    else
+        sudo apt install gcc gfortran gawk libtool texlive-full pandoc pandoc-citeproc  
+    fi
+
     #Explaination:    
     #gcc                                    # general prerequsites for building anything
     #gfortran                               # needed for mpich
     #gawk                                   # reliable math calculations with gawk (normal awk is shit)
     #libtool                                # needed for gsl
-    #pandoc pandoc-citeproc texlive-full    # converting our results.md into a pdf
-else
-    sudo apt install gcc gfortran gawk
-fi
+    #pandoc pandoc-citeproc texlive-full    # converting our results.md into a pdf (not available on LRZ)
 
+
+else
+    if [ $LRZ = "yes" ]
+    then
+
+        module purge
+        module load lrz tempdir     #obligatory
+        module load spack           #requirement for many libs
+        
+        module load intel-parallel-studio   #requires spack
+        #"intel-parallel-studio: using intel wrappers for mpicc, mpif77, etc"
+        #Intel paralell studio includes: gcc, fortran compiler, 
+
+    else
+        sudo apt install gcc gfortran gawk
+    fi
+fi
 
 echo "--------------------------------------"
 echo ">>> Downloading externa libraries   <<<"
 echo "--------------------------------------"
 
 cd "${SolverDir}"
+
 #wget tdo.sk/~janka/GliomaSolverHome/libs/lib-linux-64-bit/lib.tgz #TODO: update janas package
-wget https://syncandshare.lrz.de/getlink/fi6xQsW6vgKxt7DEoQZzjnuS/lib.tgz
+wget https://syncandshare.lrz.de/dl/fi6xQsW6vgKxt7DEoQZzjnuS/lib.tgz
 tar -zxf lib.tgz
 rm lib.tgz
+#contains: hypre-2.10.0b.tgz myVTK.tgz tbb40_20120613oss.tgz
 
-wget tdo.sk/~janka/GliomaSolverHome/libs/lib-linux-64-bit/inference_libs.tgz
-tar -zxf inference_libs.tgz
-mv inference_libs/* lib/ && rm -r inference_libs
-rm inference_libs.tgz
-
+if [ $LRZ != "yes" ]    #LRZ modules cover the content of this package
+then
+    wget tdo.sk/~janka/GliomaSolverHome/libs/lib-linux-64-bit/inference_libs.tgz
+    tar -zxf inference_libs.tgz
+    mv inference_libs/* lib/ && rm -r inference_libs
+    rm inference_libs.tgz
+    #contains: gsl-src.tgz  mpich-3.2.1-src.tgz
+fi
 
 echo " "
 echo "--------------------------------------"
@@ -61,54 +112,67 @@ echo "--------------------------------------"
 cd lib
 LIB_BASE=$(pwd)                         # ".../GliomaSolver/lib"
 
-gsl_src=gsl-src
-mpich_src=mpich-3.2.1-src
-tbb=tbb40_20120613oss
+
+echo "--------------------------------------"
+echo " Unpacking vtk:"
+echo "--------------------------------------"
+
+#we use VTK 5 even on the LRZ because there were API changes which were not updated in our MRAG implementation
+#https://vtk.org/Wiki/VTK/VTK_6_Migration/Replacement_of_SetInput
+
 vtk=myVTK
-hypre=hypre-2.10.0b
-
-
-tar -zxf ${mpich_src}.tgz
-tar -zxf ${tbb}.tgz
 tar -zxf ${vtk}.tgz
-tar -zxf ${hypre}.tgz
-
-mkdir -p mpich-install
-rm ${tbb}.tgz
 rm ${vtk}.tgz
-rm ${hypre}.tgz
 
-if [ $BI = "yes" ]          # only for Bayesian Inference 
-then
-    tar -zxf ${gsl_src}.tgz
+if [ $LRZ = "yes" ]     #LRZ compatible installation
+    then
 
-    mkdir -p gsl-install
+    #mpicc is available through intel-paralell-studio
+    module load tbb
+    module load hypre
+
+    if [ $BI = "yes" ]          # only for Bayesian Inference 
+    then
+        module load gsl
+        #pi4u_lite (torc_lite, engine_tmcmc) has till to be used from a external source
+
+    fi
+
+else        #default linux installation
+
+    echo "--------------------------------------"
+    echo " Installing mpich:"
+    echo "--------------------------------------"
+
+    mpich_src=mpich-3.2.1-src   #archive name
+    tar -zxf ${mpich_src}.tgz
+    mkdir -p mpich-install
+
+    cd "${mpich_src}"
+    make clean
+    ./configure --prefix="${LIB_BASE}"/mpich-install
+    make
+    make install
+    export PATH="${LIB_BASE}"/mpich-install/bin:$PATH
+
+    echo "---------------"
+    echo "mpicc is set to"
+    which mpicc
+    echo "---------------"
+    cd "${LIB_BASE}"
+    rm ${mpich_src}.tgz
+    rm -r ${mpich_src}
 fi
-
-
-echo "--------------------------------------"
-echo " Installing mpich:"
-echo "--------------------------------------"
-
-cd "${mpich_src}"
-make clean
-./configure --prefix="${LIB_BASE}"/mpich-install
-make
-make install
-export PATH="${LIB_BASE}"/mpich-install/bin:$PATH
-
-echo "---------------"
-echo "mpicc is set to"
-which mpicc
-echo "---------------"
-cd "${LIB_BASE}"
-rm ${mpich_src}.tgz
-rm -r ${mpich_src}
 
 
 echo "--------------------------------------"
 echo " Installing tbb:"
 echo "--------------------------------------"
+#module load tbb #throws error on making that why also on LRZ the prepacked version is used
+
+tbb=tbb40_20120613oss   #archive name
+tar -zxf ${tbb}.tgz
+rm ${tbb}.tgz
 
 cd "${tbb}"
 make clean
@@ -116,31 +180,52 @@ make
 cd "${LIB_BASE}"
 
 
-echo "--------------------------------------"
-echo " Installing Hypre:"
-echo "--------------------------------------"
-cd "${hypre}/src"
-make clean
-./configure
-make
-make install
-cd "${LIB_BASE}"
-
-if [ $BI = "yes" ]          # only for Bayesian Inference 
+if [ $LRZ != "yes" ]
 then
+
+
     echo "--------------------------------------"
-    echo " Installing gsl:"
+    echo " Installing Hypre:"
     echo "--------------------------------------"
 
-    cd "${gsl_src}"
-    ./autogen.sh
-    ./configure --enable-maintainer-mode --disable-dynamic --prefix="${LIB_BASE}"/gsl-install
+    hypre=hypre-2.10.0b     #archive name
+    tar -zxf ${hypre}.tgz
+    rm ${hypre}.tgz
+
+    cd "${hypre}/src"
+    make clean
+    ./configure
     make
     make install
     cd "${LIB_BASE}"
-    rm ${gsl_src}.tgz
-    #rm -r ${gsl_src}   #gonna throw a "rm: remove write-protected regular file 'gsl-src/gsl-config'?" hindering the flow
+fi
 
+if [ $BI = "yes" ]          # only for Bayesian Inference 
+then
+
+    if [ $LRZ != "yes" ]    #default installation
+    then
+        echo "--------------------------------------"
+        echo " Installing gsl:"
+        echo "--------------------------------------"
+
+        gsl_src=gsl-src
+        tar -zxf ${gsl_src}.tgz
+        mkdir -p gsl-install
+
+        cd "${gsl_src}"
+        ./autogen.sh
+        ./configure --enable-maintainer-mode --disable-dynamic --prefix="${LIB_BASE}"/gsl-install
+        make
+        make install
+        cd "${LIB_BASE}"
+        rm ${gsl_src}.tgz
+        #rm -r ${gsl_src}   #gonna throw a "rm: remove write-protected regular file 'gsl-src/gsl-config'?" hindering the flow
+    fi
+
+    #TODO: better way to get torc? maybe clone the current repo from https://github.com/cselab/pi4u ?
+    #We only need the "torc_lite" subdirectory form this repo. However sparse checkjputs are not yet supported properly in git
+    #git clone https://github.com/cselab/pi4u.git
 
     echo "--------------------------------------"
     echo " Installing torc:"
@@ -162,16 +247,28 @@ then
 
     cd "${SolverDir}"/tools/pi4u_lite/Inference
 
-    UserName=$(hostname -s)
     cp tools.make/Makefile .
-    cp tools.make/setup_linux.sh setup_${UserName}.sh
     cp tools.make/run_inference.sh .
-
     sed -i 's|_USER_LIB_BASE_|'"${LIB_BASE}"'|g' Makefile
-    sed -i 's|_USER_LIB_BASE_|'"${LIB_BASE}"'|g' setup_${UserName}.sh
     sed -i 's|_USER_LIB_BASE_|'"${LIB_BASE}"'|g' run_inference.sh
 
-    source setup_${UserName}.sh
+    if [ $LRZ = "yes" ]
+    then
+        cp tools.make/setup_lrz.sh .
+
+        sed -i 's|_USER_LIB_BASE_|'"${LIB_BASE}"'|g' setup_lrz.sh
+
+        source setup_lrz.sh
+
+    else
+        UserName=$(hostname -s)
+        cp tools.make/setup_linux.sh setup_${UserName}.sh
+        
+        sed -i 's|_USER_LIB_BASE_|'"${LIB_BASE}"'|g' setup_${UserName}.sh
+
+        source setup_${UserName}.sh
+    fi
+
     make clean
     make
 
@@ -185,17 +282,31 @@ echo ">>>       Creating Makefile       <<<"
 echo "--------------------------------------"
 cd "${SolverDir}"/makefile
 
-UserName=$(hostname -s)
-cp tools.make/make.linux make.${UserName}
 cp tools.make/Makefile .
-cp tools.make/setup_linux.sh setup_${UserName}.sh
 
-#replace placeholders in files
-sed -i 's|_USER_LIB_BASE_|'"${LIB_BASE}"'|g' make.${UserName}
-sed -i 's|_USER_NAME_|'"${UserName}"'|g' Makefile
-sed -i 's|_USER_LIB_BASE_|'"${LIB_BASE}"'|g' setup_${UserName}.sh
+if [ $LRZ = "yes" ]
+then
+    cp tools.make/make.lrz .
+    cp tools.make/setup_lrz.sh .
 
-source setup_${UserName}.sh
+    #replace placeholders in files
+    sed -i 's|_USER_LIB_BASE_|'"${LIB_BASE}"'|g' make.lrz
+    sed -i 's|_USER_LIB_BASE_|'"${LIB_BASE}"'|g' setup_lrz.sh
+
+    source setup_lrz.sh
+else
+    UserName=$(hostname -s)
+    
+    cp tools.make/make.linux make.${UserName}
+    cp tools.make/setup_linux.sh setup_${UserName}.sh
+
+    #replace placeholders in files
+    sed -i 's|_USER_LIB_BASE_|'"${LIB_BASE}"'|g' make.${UserName}
+    sed -i 's|_USER_NAME_|'"${UserName}"'|g' Makefile
+    sed -i 's|_USER_LIB_BASE_|'"${LIB_BASE}"'|g' setup_${UserName}.sh
+
+    source setup_${UserName}.sh
+fi
 
 echo "  "
 echo "==============================================="
@@ -208,16 +319,25 @@ echo "---------------------------------------"
 
 #cat setup_${UserName}.sh
 echo "LIB_BASE=\"${LIB_BASE}\""
-echo "export LD_LIBRARY_PATH=\$LIB_BASE/tbb40_20120613oss/build/linux_intel64_gcc_cc4.6.1_libc2.5_kernel2.6.18_release/:\$LD_LIBRARY_PATH"
 echo "export LD_LIBRARY_PATH=\$LIB_BASE/myVTK/lib/vtk-5.4/:\$LD_LIBRARY_PATH"
-echo "export LD_LIBRARY_PATH=\$LIB_BASE/hypre-2.10.0b/src/hypre/lib/:\$LD_LIBRARY_PATH"
+echo "export LD_LIBRARY_PATH=\$LIB_BASE/tbb40_20120613oss/build/linux_intel64_gcc_cc4.6.1_libc2.5_kernel2.6.18_release/:\$LD_LIBRARY_PATH"
+    
+if [ $LRZ != "yes" ]
+then
+    echo "export LD_LIBRARY_PATH=\$LIB_BASE/hypre-2.10.0b/src/hypre/lib/:\$LD_LIBRARY_PATH"
+    echo "export PATH=\$LIB_BASE/mpich-install/bin:\$PATH"
+fi
+
 if [ $BI = "yes" ]          # only for Bayesian Inference 
 then
-    echo "export LD_LIBRARY_PATH=\$LIB_BASE/gsl-install/lib/:\$LD_LIBRARY_PATH"
+    if [ $LRZ != "yes" ]
+    then
+        echo "export LD_LIBRARY_PATH=\$LIB_BASE/gsl-install/lib/:\$LD_LIBRARY_PATH"
+    fi
     echo "export PATH=\$LIB_BASE/usr/torc/bin:\$PATH"
     #cat "${SolverDir}/tools/pi4u_lite/Inference/setup_${UserName}.sh"
 fi
-echo "export PATH=\$LIB_BASE/mpich-install/bin:\$PATH"
+   
 
 echo "---------------------------------------"
 echo "To compile the GliomaSolver do"

--- a/Simulations/PatientInference/setupInference.sh
+++ b/Simulations/PatientInference/setupInference.sh
@@ -5,6 +5,10 @@ echo "------------------------------------------------------"
 echo "          SETTING-UP INFERENCE ENVIROMENT             "
 echo "------------------------------------------------------"
 
+if [ $LRZ_SYSTEM_SEGMENT != "" ]
+then
+    module load matlab
+fi
 
 InputFile=Input.txt
 DataPath=$(  cat ${InputFile} | awk -F '=' '/^DataPath/ {print $2}')

--- a/makefile/tools.make/Makefile
+++ b/makefile/tools.make/Makefile
@@ -5,7 +5,7 @@ hn ?= $(shell hostname)
 
 ifneq "$(findstring _USER_NAME_,$(shell hostname))" ""
 include make._USER_NAME_
-else ifneq "$(findstring mpp,$(shell hostname))" ""
+else ifdef LRZ_SYSTEM_SEGMENT
 include make.lrz
 else ifneq "$(findstring kraken,$(shell hostname))" ""
 include make.kraken

--- a/makefile/tools.make/make.lrz
+++ b/makefile/tools.make/make.lrz
@@ -3,7 +3,7 @@ OPENMP_FLAG= -fopenmp -fpermissive
 
 # Set up paths libraries
 
-LIB_BASE="/dss/dsshome1/lxc0D/ge69yed2/IBBM/GliomaSolver/LRZversion/lib"
+LIB_BASE="_USER_LIB_BASE_"
 
 
 TBB_INC_DIR=$(LIB_BASE)/tbb40_20120613oss/include

--- a/makefile/tools.make/make.lrz
+++ b/makefile/tools.make/make.lrz
@@ -2,21 +2,32 @@ CC = g++ -O3 -Wno-deprecated
 OPENMP_FLAG= -fopenmp -fpermissive
 
 # Set up paths libraries
-LIB_BASE=/home/hpc/txh01/di49zin/GliomaAdvance/lib
+
+LIB_BASE="/dss/dsshome1/lxc0D/ge69yed2/IBBM/GliomaSolver/LRZversion/lib"
+
 
 TBB_INC_DIR=$(LIB_BASE)/tbb40_20120613oss/include
 TBB_LIB_DIR=$(LIB_BASE)/tbb40_20120613oss/build/linux_intel64_gcc_cc4.6.1_libc2.5_kernel2.6.18_release
 
+
+#LRZ TBB (does throw errors when makeing)
+#TBB_INC_DIR=/lrz/sys/intel/studio2018_p4/compilers_and_libraries_2018.5.274/linux/tbb/include
+#TBB_LIB_DIR=/lrz/sys/intel/studio2018_p4/compilers_and_libraries_2018.5.274/linux/tbb/lib/intel64/gcc4.1   #Exctracted from $TBB_SHLIB
+
+
+#LRZ VTK (5.6 causes: "./brain: error while loading shared libraries: libvtkWidgets.so.5.6: cannot open shared object file: No such file or directory")
+#VTK_INC_DIR=/lrz/sys/spack/release/20.1/opt/haswell/vtk/8.1.2-gcc-xp3nkvw/include/vtk-8.1
+#VTK_LIB_DIR=/lrz/sys/spack/release/20.1/opt/haswell/vtk/8.1.2-gcc-xp3nkvw/lib
+#everything over vtk 5.6 is to new for the MRAG implementation
+#VTK_INC_DIR=/lrz/sys/tools/proot/images/centos/Freesurfer/freesurfer/lib/vtk/include/vtk-5.6
+#VTK_LIB_DIR=/lrz/sys/tools/proot/images/centos/Freesurfer/freesurfer/lib/vtk/lib/vtk-5.6
 VTK_INC_DIR=$(LIB_BASE)/myVTK/include/vtk-5.4
 VTK_LIB_DIR=$(LIB_BASE)/myVTK/lib/vtk-5.4
 
-#HYPRE_INC_DIR=$HYPRE_INC
-#HYPRE_LIB_DIR=$HYPRE_LIB
 
-#HYPRE_INC_DIR=/lrz/sys/libraries/hypre/2.11.2/include
-#HYPRE_LIB_DIR=/lrz/sys/libraries/hypre/2.11.2/lib
-HYPRE_INC_DIR=$(LIB_BASE)/hypre-2.10.0b/src/hypre/include
-HYPRE_LIB_DIR=$(LIB_BASE)/hypre-2.10.0b/src/hypre/lib
+HYPRE_INC_DIR=/lrz/sys/libraries/hypre/2.11.2/include
+HYPRE_LIB_DIR=/lrz/sys/libraries/hypre/2.11.2/lib
+
 
 export LD_LIBRARY_PATH:=$(VTK_LIB_DIR):$(LD_LIBRARY_PATH)
 export LD_LIBRARY_PATH:=$(TBB_LIB_DIR):$(LD_LIBRARY_PATH)
@@ -26,13 +37,3 @@ export LANG=C
 export LC_ALL=C
 
 CPPFLAGS+= -I$(TBB_INC_DIR) -I$(VTK_INC_DIR) -I..
-
-
-# NOTE: If using LRZ hypre
-#HYPRE_INC_DIR = $HYPRE_INC
-#HYPRE_LIB_DIR = $HYPRE_LIB
-# or without shortcuts, set the direct path
-# HYPRE_INC_DIR=/lrz/sys/libraries/hypre/2.11.2_impi51/include
-# HYPRE_LIB_DIR=/lrz/sys/libraries/hypre/2.11.2_impi51/lib
-
-

--- a/makefile/tools.make/setup_lrz.sh
+++ b/makefile/tools.make/setup_lrz.sh
@@ -1,27 +1,53 @@
 # Load modules
 module purge
-module load admin/1.0 lrz/default intel/17.0 mkl/2017
-module load gsl/2.3 blast gcc/4.9
-echo "Currently loaded modules:"
+#module load admin/1.0 lrz/default intel/17.0 mkl/2017
+#module load gsl/2.3 blast gcc/4.9
+
+module load lrz tempdir     #obligatory
+module load spack           #requirement for many libs
+        
+module load intel-parallel-studio   #requires spack
+#"intel-parallel-studio: using intel wrappers for mpicc, mpif77, etc"
+#Intel paralell studio includes: gcc, fortran compiler, 
+
+#gawk and libtool is allready existent at LRZ
+module load texlive
+
+#module load tbb #throws error on making
+module load hypre
+module load gsl
+
 
 # Set up paths libraries
-LIB_BASE=/home/hpc/txh01/di49zin/GliomaAdvance/lib
-export LD_LIBRARY_PATH=$LIB_BASE/tbb40_20120613oss/build/linux_intel64_gcc_cc4.6.1_libc2.5_kernel2.6.18_release/:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=$LIB_BASE/myVTK/lib/vtk-5.4/:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=$LIB_BASE/hypre-2.10.0b/src/hypre/lib/:$LD_LIBRARY_PATH
+LIB_BASE="/dss/dsshome1/lxc0D/ge69yed2/IBBM/GliomaSolver/LRZversion/lib"
 
-#export PATH=$HOME/usr/torc/bin:$PATH
-#export PATH=$PATH:$HOME/pi4u-libs/mpich-install/bin/
-#export LD_LIBRARY_PATH=$HOME/pi4u-libs/mpich-install/lib/:$LD_LIBRARY_PATH
-echo "we use this mpicc:"
-which mpicc
+export LD_LIBRARY_PATH=/lrz/sys/libraries/gsl/2.4/lib/:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=/lrz/sys/libraries/hypre/2.11.2/lib/:$LD_LIBRARY_PATH
+#export LD_LIBRARY_PATH=/lrz/sys/intel/studio2018_p4/compilers_and_libraries_2018.5.274/linux/tbb/lib/intel64/gcc4.1:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$LIB_BASE/tbb40_20120613oss/build/linux_intel64_gcc_cc4.6.1_libc2.5_kernel2.6.18_release/:$LD_LIBRARY_PATH
+
+
+#we use VTK 5 because there were API changes which were not updated in our MRAG imlementation
+#https://vtk.org/Wiki/VTK/VTK_6_Migration/Replacement_of_SetInput
+#export LD_LIBRARY_PATH=/lrz/sys/spack/release/20.1/opt/haswell/vtk/8.1.2-gcc-xp3nkvw/include/vtk-8.1:$LD_LIBRARY_PATH
+#export LD_LIBRARY_PATH=/lrz/sys/tools/proot/images/centos/Freesurfer/freesurfer/lib/vtk/include/vtk-5.6/:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$LIB_BASE/myVTK/lib/vtk-5.4/:$LD_LIBRARY_PATH
+
+#vtk?
+#/lrz/sys/applications/OpenFOAM/OpenFOAM-v1812+.impi.gcc/ThirdParty-v1812/ParaView-v5.6.0/VTK/Common/Core/
+#/lrz/sys/graphics/paraview/5.5.0/paraview_gl/include/paraview-5.5
+#/lrz/sys/tools/proot/images/centos/Freesurfer/freesurfer/lib/vtk/include/vtk-5.6/
+#/lrz/sys/applications/OpenFOAM/OpenFOAM-6.0.impi.intel/ThirdParty-6/ParaView-5.8.0/VTK/Common/Core/
+#/lrz/sys/spack/.tmp/test/mayavi/envs/x86_avx512/mayavi04/.spack-env/view/include/vtk-8.1/
+#/lrz/sys/spack/release/20.1/opt/haswell/paraview/5.6.2-gcc-u6argwl/include/paraview-5.6/vtkPoints.h
+#/lrz/sys/spack/release/20.1/opt/haswell/vtk/8.1.2-gcc-xp3nkvw/include/vtk-8.1/vtkPoints.h
+#/lrz/sys/spack/release/19.1.1/opt/x86_avx2/paraview/5.4.1-gcc-jian24h/include/paraview-5.4/vtkPoints.h
+#/lrz/sys/spack/release/19.1.1/opt/x86_avx2/vtk/8.0.1-gcc-u7phuwh/include/vtk-8.0/vtkPoints.h
+
 
 #needed on LRZ for MAC login discompatiblity
 export LANG=C
 export LC_ALL=C
 
-# NOTE: To use hypre library provided by LRZ do:
-# module load hypre
-# export LD_LIBRARY_PATH=/lrz/sys/libraries/hypre/2.11.2_impi51/lib/:$LD_LIBRARY_PATH
 
 

--- a/makefile/tools.make/setup_lrz.sh
+++ b/makefile/tools.make/setup_lrz.sh
@@ -19,7 +19,7 @@ module load gsl
 
 
 # Set up paths libraries
-LIB_BASE="/dss/dsshome1/lxc0D/ge69yed2/IBBM/GliomaSolver/LRZversion/lib"
+LIB_BASE="_USER_LIB_BASE_"
 
 export LD_LIBRARY_PATH=/lrz/sys/libraries/gsl/2.4/lib/:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=/lrz/sys/libraries/hypre/2.11.2/lib/:$LD_LIBRARY_PATH

--- a/tools/pi4u_lite/Inference/tools.make/Makefile
+++ b/tools/pi4u_lite/Inference/tools.make/Makefile
@@ -4,8 +4,8 @@ ifdef LRZ_SYSTEM_SEGMENT	#we are on a LRZ system
 	GSL_INC_DIR=/lrz/sys/libraries/gsl/2.3/include
 	GSL_LIB_DIR=/lrz/sys/libraries/gsl/2.3/lib
 else
-	GSL_INC_DIR="/dss/dsshome1/lxc0D/ge69yed2/IBBM/GliomaSolver/LRZversion/lib"/gsl-install/include/
-	GSL_LIB_DIR="/dss/dsshome1/lxc0D/ge69yed2/IBBM/GliomaSolver/LRZversion/lib"/gsl-install/lib/
+	GSL_INC_DIR="_USER_LIB_BASE_"/gsl-install/include/
+	GSL_LIB_DIR="_USER_LIB_BASE_"/gsl-install/lib/
 endif
 
 #ifneq "$(findstring kraken, $(shell hostname))" ""

--- a/tools/pi4u_lite/Inference/tools.make/Makefile
+++ b/tools/pi4u_lite/Inference/tools.make/Makefile
@@ -1,13 +1,11 @@
-hn ?= $(shell hostname)
-
-ifneq "$(findstring mpp, $(shell hostname))" ""
-export LANG=C
-export LC_ALL=C
-GSL_INC_DIR=/lrz/sys/libraries/gsl/2.3/include
-GSL_LIB_DIR=/lrz/sys/libraries/gsl/2.3/lib
+ifdef LRZ_SYSTEM_SEGMENT	#we are on a LRZ system
+	export LANG=C
+	export LC_ALL=C
+	GSL_INC_DIR=/lrz/sys/libraries/gsl/2.3/include
+	GSL_LIB_DIR=/lrz/sys/libraries/gsl/2.3/lib
 else
-GSL_INC_DIR="_USER_LIB_BASE_"/gsl-install/include/
-GSL_LIB_DIR="_USER_LIB_BASE_"/gsl-install/lib/
+	GSL_INC_DIR="/dss/dsshome1/lxc0D/ge69yed2/IBBM/GliomaSolver/LRZversion/lib"/gsl-install/include/
+	GSL_LIB_DIR="/dss/dsshome1/lxc0D/ge69yed2/IBBM/GliomaSolver/LRZversion/lib"/gsl-install/lib/
 endif
 
 #ifneq "$(findstring kraken, $(shell hostname))" ""


### PR DESCRIPTION
1. Fixed LRZ sync and share download link in the installer
2. Made the "setup_inference.sh" include the matlab module if we are working on the LRZ. (This was missing for the setup script to work on LRZ)
3. Made the installer work properly when started on the LRZ:

> - removed all sudo dependencies by using the available modules of the LRZ. The packages that would be downloaded and installed in the normal installation process are all available as modules on the LRZ. Except pandoc. Therfore the Patient Inference cannot generate graphics in the Results.pdf. We still need to find a workaround for this to make the Patient inference 100% compatible with the cluster
> - removed dependencies on libraries that are available as modules. Following pre-packed packages will not be used on the LRZ cluster because an working equivalent is present:
> > - **hypre-2.10.0b.tgz**
> > - **gsl-src.tgz**
> > - **mpich-3.2.1-src.tgz**
> - Following packes could not be replaced:
> > - **myVTK.tgz**  ,because VTK 5 is required as [there were API changes](https://vtk.org/Wiki/VTK/VTK_6_Migration/Replacement_of_SetInput) which were not updated in our MRAG implementation
> > - **tbb40_20120613oss.tgz** ,because the version on the cluster causes errors when making executables. This may need to be investigated further

Disclaimer:
I did test installing and making on the cluster. The functionality of the executables will be tested when preparing the next commit in the following weeks.