### PR TITLE
Replaced hardcoded "/tmp/" directory

### DIFF
--- a/tools/DataProcessing/lib/toolbox_matlab_nifti/load_nifti.m
+++ b/tools/DataProcessing/lib/toolbox_matlab_nifti/load_nifti.m
@@ -65,7 +65,7 @@ if(strcmpi(ext,'.gz'))
   gzipped =  round(rand(1)*10000000 + ...
 		   sum(int16(niftifile))) + round(cputime);
   ind = findstr(niftifile, '.');
-  new_niftifile = sprintf('/tmp/tmp%d.nii', gzipped);
+  new_niftifile = sprintf('%s/tmp%d.nii',tempdir, gzipped);
   %fprintf('Uncompressing %s to %s\n',niftifile,new_niftifile);
   if(strcmp(computer,'MAC') || strcmp(computer,'MACI') || ismac)
     unix(sprintf('gunzip -c %s > %s', niftifile, new_niftifile));


### PR DESCRIPTION
On the LRZ cluster the "/tmp/" directory is severely restricted cocerning its size.
Therefore we should use the official temporary directory of the cluster.
Fortunately, matlab environment variable `tmepdir` holds teh value of the clusters `TMPDIR` environment variable.

**However**, `TMPDIR` may not be set on non-LRZ systems. The matlab documentation does not clearly describe which value `tempdir` will take in such cases. I guess its takes the linux standard `/tmp/` diretory and is not empty. As I do not know for sure, this commit should therefore be tested on non-LRZ systems (with a working matlab environment).
It would be sufficient to open a matlab shell and see if `fprintf(tempdir)` has a reasonable directory.
(I cannot do that myself currently)